### PR TITLE
Add travis-ci support and README build badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk6
+  - openjdk7
+install:
+  - mkdir -p $PWD/opt
+  - pushd $PWD/opt
+  - curl https://s3.amazonaws.com/ply-buildtool/ply.tar | tar xz
+  - popd
+env:
+  - PLY_HOME=$PWD/opt/ply PATH=$PLY_HOME/bin:$PATH
+script:
+  - pushd ply-util
+  - ply install
+  - popd
+  - ply test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Overview
 --------
 
+[![Build Status](https://travis-ci.org/blangel/ply.svg?branch=master)](https://travis-ci.org/blangel/ply)
+
 Ply is a build tool.  It is sensible, fast and a joy to use. 
 
 Features


### PR DESCRIPTION
This adds the ability to build the ply repository on travis-ci and a build badge in the README front-page.

I started working on this when I could not get the tests locally to run. Interestingly, I got the same problems on Travis:

* The tests do not run successfully. See https://travis-ci.org/dmacvicar/ply/jobs/136072613

```console
3.09s$ ply test
[ply] building ply, 1.0
[dep] Resolving 1 dependency for ply.
[compile] Compiling 32 source files for ply
[compile]   error   cannot find symbol   symbol:   method valueDecorated()   in variable prop of type net.ocheyedan.ply.props.PropFile.Prop @ line 182 in file:net.ocheyedan.ply.cmd.config.Get
[compile]   error   cannot find symbol   symbol:   variable DECORATOR_SCOPED   in class net.ocheyedan.ply.props.Filter @ line 63 in file:net.ocheyedan.ply.cmd.config.Get
[compile]   error   no suitable method found for parse(net.ocheyedan.ply.props.PropFile,<nulltype>)     method 
... and more
```

* If I do `ply` on the *ply* top level project, it looks for `ply-util` but does not find it as a submodule in the same directory. I have to manually go into `ply-util` and do `ply install` before building the top-level.