### PR TITLE
Remove dependency on jasypt

### DIFF
--- a/ply-util/src/test/java/net/ocheyedan/ply/PwdUtilTest.java
+++ b/ply-util/src/test/java/net/ocheyedan/ply/PwdUtilTest.java
@@ -1,0 +1,21 @@
+package net.ocheyedan.ply;
+
+import org.junit.Test;
+import java.util.UUID;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+public class PwdUtilTest {
+
+    @Test
+    public void testSimpleEncryption() {
+        String text = UUID.randomUUID().toString();
+        String enc = PwdUtil.encrypt(text);
+        assertThat(text, not(equalTo(enc)));
+        String dec = PwdUtil.decrypt(enc);
+        assertEquals(text, dec);
+    }
+
+}


### PR DESCRIPTION
A build tool should is very low in the food chain and should have as little dependencies as possible.

Obfuscating password with fixed password encryption does not have much sense, but if it is going to be done, it is not worth to depend on an additional library for that.

This PR ports the obfuscation to sun.misc.BASE64_. We can use sun.misc.BASE64_ as it is already used in net.ocheyedan.ply.dep.BasicAuth. The PR also adds a previously non-existent test.

In the future should look for a Apache licensed file and copy it into the
tree as sun.misc.\* is not public API.
